### PR TITLE
GHA: update workflows

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,13 +16,13 @@ jobs:
         GO_VERSION: ['1.24', '1.23', '1.22', '1.21', '1.20']
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.GO_VERSION }}
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
     - name: Build
       run: |
         go build -v ./...
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
     - name: Coverage

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        GO_VERSION: ['1.24', '1.23', '1.22', '1.21', '1.20']
+        GO_VERSION: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
     - name: Coverage
       run: |
         go test -race -v \


### PR DESCRIPTION
- add go 1.25 and make it default
- bump actions:
    - actions/checkout: v4 -> v6
    - actions/setup-go: v5 -> v6
    - golangci/golangci-lint-action: v7 -> v9
